### PR TITLE
Update ocean heat capacity constant to 3996

### DIFF
--- a/cfgs/tn0.25v3/context_nemo.xml
+++ b/cfgs/tn0.25v3/context_nemo.xml
@@ -11,7 +11,7 @@
        <variable id="ref_month" type="int"> 01 </variable>
        <variable id="ref_day"   type="int"> 01 </variable>
        <variable id="rau0"      type="float" > 1026.0 </variable>
-       <variable id="cpocean"   type="float" > 3991.86795711963 </variable>
+       <variable id="cpocean"   type="float" > 3996.0 </variable>
        <variable id="convSpsu"  type="float" > 0.99530670233846  </variable>
        <variable id="rhoic"     type="float" > 917.0 </variable>
        <variable id="rhosn"     type="float" > 330.0 </variable>

--- a/interface/src/eosbn2.F90
+++ b/interface/src/eosbn2.F90
@@ -1356,7 +1356,7 @@ CONTAINS
       IF(lwm) WRITE( numond, nameos )
       !
       rho0        = 1026._wp                 !: volumic mass of reference     [kg/m3]
-      rcp         = 3991.86795711963_wp      !: heat capacity     [J/K]
+      rcp         = 3996._wp !3991.86795711963_wp      !: heat capacity     [J/K]
       !
       IF(lwp) THEN                ! Control print
          WRITE(numout,*)


### PR DESCRIPTION
Update the value of the ocean heat capacity constant to the values of 3996.
This update is done to keep the same value as used in the other components of the coupled model.